### PR TITLE
added my-combinator

### DIFF
--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -73,6 +73,12 @@ this.postcondition =
     (predicate = throwable) and (throwable = 'Failed postcondition') unless predicate
     this.after -> throw throwable unless predicate.apply(this, arguments)
 
+# Sugar to reference instance method by name
+this.my =
+  (name)->
+    ->
+      this[name].apply this, arguments
+
 # ## Asynchronous Method Combinators
 
 this.async = do (async = undefined) ->

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -112,8 +112,21 @@ this.async = do (async = undefined) ->
 # ## Combinator Helpers
 this.helpers =
 
-  # Sugar to reference instance method by name
+  # Sugar to reference instance methods by name.
+  # It also threads multiple methods, allows you to use unbound functions as well as strings, and
+  # if the first parameter is an array, it auto-splats it
   my:
-    (name)->
-      ->
-        this[name].apply this, arguments
+    (names...)->
+      if typeof(names[0]) is "object" #i.e. array
+        names = names[0]
+      (args...)->
+        result = undefined
+        for name in names
+          func =
+            if typeof(name) == "string"
+              this[name]
+            else
+              name
+          result = func.apply this, args
+          args = [result]
+        result

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -141,8 +141,7 @@ this.helpers = do (helpers = {}, combinators = this)->
  
   # Similar to threading macros, but works on instance variable names
   helpers.pipeMy =
-    (funcRefs...)->
-      helpers.pipe.apply this,
-        (combinators.splatter helpers.my) funcRefs
+    ->
+      helpers.pipe ((combinators.splatter helpers.my) arguments)...
  
   helpers

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -110,23 +110,32 @@ this.async = do (async = undefined) ->
   async
 
 # ## Combinator Helpers
-this.helpers =
+this.helpers = do (helpers = {})->
 
   # Sugar to reference instance methods by name.
   # It also threads multiple methods, allows you to use unbound functions as well as strings, and
   # if the first parameter is an array, it auto-splats it
-  my:
-    (names...)->
-      if typeof(names[0]) is "object" #i.e. array
-        names = names[0]
+  helpers.my =
+    (name)->
+      (args...)->
+        func = this[name]
+        func.apply this, args
+
+  # Similar to threading macros
+  helpers.pipe  =
+    (functions...)->
       (args...)->
         result = undefined
-        for name in names
-          func =
-            if typeof(name) == "string"
-              this[name]
-            else
-              name
+        for func in functions
           result = func.apply this, args
           args = [result]
         result
+
+  # Similar to threading macros, but 
+  helpers.pipeMy =
+    (funcRefs...)->
+      functions = for funcRef in funcRefs
+        helpers.my funcRef
+      helpers.pipe.apply this, functions
+ 
+  helpers

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -120,11 +120,9 @@ this.async = do (async = undefined) ->
   async
 
 # ## Combinator Helpers
-this.helpers = do (helpers = {})->
+this.helpers = do (helpers = {}, combinators = this)->
 
   # Sugar to reference instance methods by name.
-  # It also threads multiple methods, allows you to use unbound functions as well as strings, and
-  # if the first parameter is an array, it auto-splats it
   helpers.my =
     (name)->
       (args...)->
@@ -140,12 +138,11 @@ this.helpers = do (helpers = {})->
           result = func.apply this, args
           args = [result]
         result
-
-  # Similar to threading macros, but 
+ 
+  # Similar to threading macros, but works on instance variable names
   helpers.pipeMy =
     (funcRefs...)->
-      functions = for funcRef in funcRefs
-        helpers.my funcRef
-      helpers.pipe.apply this, functions
+      helpers.pipe.apply this,
+        (combinators.splatter helpers.my) funcRefs
  
   helpers

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -73,12 +73,6 @@ this.postcondition =
     (predicate = throwable) and (throwable = 'Failed postcondition') unless predicate
     this.after -> throw throwable unless predicate.apply(this, arguments)
 
-# Sugar to reference instance method by name
-this.my =
-  (name)->
-    ->
-      this[name].apply this, arguments
-
 # ## Asynchronous Method Combinators
 
 this.async = do (async = undefined) ->
@@ -114,3 +108,12 @@ this.async = do (async = undefined) ->
         async_predicate.apply(this, argv.concat(decorated_base))
 
   async
+
+# ## Combinator Helpers
+this.helpers =
+
+  # Sugar to reference instance method by name
+  my:
+    (name)->
+      ->
+        this[name].apply this, arguments

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -157,26 +157,45 @@
     return async;
   })(void 0);
 
-  this.helpers = {
-    my: function() {
-      var names;
-      names = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-      if (typeof names[0] === "object") {
-        names = names[0];
-      }
+  this.helpers = (function(helpers) {
+    helpers.my = function(name) {
       return function() {
-        var args, func, name, result, _i, _len;
+        var args, func;
+        args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+        func = this[name];
+        return func.apply(this, args);
+      };
+    };
+    helpers.pipe = function() {
+      var functions;
+      functions = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      return function() {
+        var args, func, result, _i, _len;
         args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
         result = void 0;
-        for (_i = 0, _len = names.length; _i < _len; _i++) {
-          name = names[_i];
-          func = typeof name === "string" ? this[name] : name;
+        for (_i = 0, _len = functions.length; _i < _len; _i++) {
+          func = functions[_i];
           result = func.apply(this, args);
           args = [result];
         }
         return result;
       };
-    }
-  };
+    };
+    helpers.pipeMy = function() {
+      var funcRef, funcRefs, functions;
+      funcRefs = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      functions = (function() {
+        var _i, _len, _results;
+        _results = [];
+        for (_i = 0, _len = funcRefs.length; _i < _len; _i++) {
+          funcRef = funcRefs[_i];
+          _results.push(helpers.my(funcRef));
+        }
+        return _results;
+      })();
+      return helpers.pipe.apply(this, functions);
+    };
+    return helpers;
+  })({});
 
 }).call(this);

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -173,7 +173,7 @@
     return async;
   })(void 0);
 
-  this.helpers = (function(helpers) {
+  this.helpers = (function(helpers, combinators) {
     helpers.my = function(name) {
       return function() {
         var args, func;
@@ -198,20 +198,11 @@
       };
     };
     helpers.pipeMy = function() {
-      var funcRef, funcRefs, functions;
+      var funcRefs;
       funcRefs = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-      functions = (function() {
-        var _i, _len, _results;
-        _results = [];
-        for (_i = 0, _len = funcRefs.length; _i < _len; _i++) {
-          funcRef = funcRefs[_i];
-          _results.push(helpers.my(funcRef));
-        }
-        return _results;
-      })();
-      return helpers.pipe.apply(this, functions);
+      return helpers.pipe.apply(this, (combinators.splatter(helpers.my))(funcRefs));
     };
     return helpers;
-  })({});
+  })({}, this);
 
 }).call(this);

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -98,12 +98,6 @@
     });
   };
 
-  this.my = function(name) {
-    return function() {
-      return this[name].apply(this, arguments);
-    };
-  };
-
   this.async = (function(async) {
     async = function(fn) {
       return function() {
@@ -162,5 +156,13 @@
     };
     return async;
   })(void 0);
+
+  this.helpers = {
+    my: function(name) {
+      return function() {
+        return this[name].apply(this, arguments);
+      };
+    }
+  };
 
 }).call(this);

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -158,9 +158,23 @@
   })(void 0);
 
   this.helpers = {
-    my: function(name) {
+    my: function() {
+      var names;
+      names = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      if (typeof names[0] === "object") {
+        names = names[0];
+      }
       return function() {
-        return this[name].apply(this, arguments);
+        var args, func, name, result, _i, _len;
+        args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+        result = void 0;
+        for (_i = 0, _len = names.length; _i < _len; _i++) {
+          name = names[_i];
+          func = typeof name === "string" ? this[name] : name;
+          result = func.apply(this, args);
+          args = [result];
+        }
+        return result;
       };
     }
   };

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -98,6 +98,12 @@
     });
   };
 
+  this.my = function(name) {
+    return function() {
+      return this[name].apply(this, arguments);
+    };
+  };
+
   this.async = (function(async) {
     async = function(fn) {
       return function() {

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -198,9 +198,7 @@
       };
     };
     helpers.pipeMy = function() {
-      var funcRefs;
-      funcRefs = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-      return helpers.pipe.apply(this, (combinators.splatter(helpers.my))(funcRefs));
+      return helpers.pipe.apply(helpers, (combinators.splatter(helpers.my))(arguments));
     };
     return helpers;
   })({}, this);

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -457,3 +457,60 @@ describe "helpers", ->
 
       eg = new MyClass()
       expect(eg.double 4).toBe 8
+
+    it "should pipe successive functions in args", ->
+
+      addAndSquareFunction = C.helpers.my "add", "square"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class MyClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+        add: (x,y)-> x + y
+        square: (n)-> n*n
+
+      eg = new MyClass()
+      expect(eg.doubleAndSquare 4).toBe 64
+
+    it "should pipe to array of functions", ->
+
+      addAndSquareFunction = C.helpers.my ["add", "square"]
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class MyClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+        add: (x,y)-> x + y
+        square: (n)-> n*n
+
+      eg = new MyClass()
+      expect(eg.doubleAndSquare 4).toBe 64
+
+    it "should should allow actual functions to be threaded as well", ->
+
+      add = (x,y)-> x + y
+      addAndSquareFunction = C.helpers.my add, "square"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class MyClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+        square: (n)-> n*n
+
+      eg = new MyClass()
+      expect(eg.doubleAndSquare 4).toBe 64

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -330,25 +330,6 @@ describe "Method Combinators", ->
       expect(-> sane.setSanity(true)).not.toThrow 'Failed precondition'
       expect(-> sane.setSanity(false)).not.toThrow 'Failed precondition'
 
-  describe "my combinator", ->
-    it "should reference instance method", ->
-
-      addFunction = C.my "add"
-      
-      repeatArg = (func)->
-        (firstArg)->
-          func.apply this, [firstArg, firstArg]
-      
-      class MyClass
-        double:
-          repeatArg \
-          addFunction
-
-        add: (x,y)-> x + y
-
-      eg = new MyClass()
-      expect(eg.double 4).toBe 8
-
 describe "Asynchronous Method Combinators", ->
 
   a = undefined
@@ -453,3 +434,26 @@ describe "Asynchronous Method Combinators", ->
         decorate(base) 'no', ->
 
         expect(a).toEqual([])
+
+
+describe "helpers", ->
+
+  describe "my", ->
+  
+    it "should reference instance method", ->
+
+      addFunction = C.helpers.my "add"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+      
+      class MyClass
+        double:
+          repeatArg \
+          addFunction
+
+        add: (x,y)-> x + y
+
+      eg = new MyClass()
+      expect(eg.double 4).toBe 8

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -460,7 +460,7 @@ describe "helpers", ->
 
   describe "pipe", ->
 
-    it "should should allow actual (and my-created) functions to be threaded", ->
+    it "should allow actual (and my-created) functions to be threaded", ->
 
       add = (x,y)-> x + y
       addAndSquareFunction = C.helpers.pipe add, C.helpers.my("square")
@@ -469,14 +469,14 @@ describe "helpers", ->
         (firstArg)->
           func.apply this, [firstArg, firstArg]
 
-      class MyClass
+      class PipeClass
         doubleAndSquare:
           repeatArg \
           addAndSquareFunction
 
         square: (n)-> n*n
 
-      eg = new MyClass()
+      eg = new PipeClass()
       expect(eg.doubleAndSquare 4).toBe 64
 
   describe "pipe my", ->
@@ -489,7 +489,7 @@ describe "helpers", ->
         (firstArg)->
           func.apply this, [firstArg, firstArg]
 
-      class MyClass
+      class PipeMyClass
         doubleAndSquare:
           repeatArg \
           addAndSquareFunction
@@ -497,5 +497,5 @@ describe "helpers", ->
         add: (x,y)-> x + y
         square: (n)-> n*n
 
-      eg = new MyClass()
+      eg = new PipeMyClass()
       expect(eg.doubleAndSquare 4).toBe 64

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -458,48 +458,12 @@ describe "helpers", ->
       eg = new MyClass()
       expect(eg.double 4).toBe 8
 
-    it "should pipe successive functions in args", ->
+  describe "pipe", ->
 
-      addAndSquareFunction = C.helpers.my "add", "square"
-      
-      repeatArg = (func)->
-        (firstArg)->
-          func.apply this, [firstArg, firstArg]
-
-      class MyClass
-        doubleAndSquare:
-          repeatArg \
-          addAndSquareFunction
-
-        add: (x,y)-> x + y
-        square: (n)-> n*n
-
-      eg = new MyClass()
-      expect(eg.doubleAndSquare 4).toBe 64
-
-    it "should pipe to array of functions", ->
-
-      addAndSquareFunction = C.helpers.my ["add", "square"]
-      
-      repeatArg = (func)->
-        (firstArg)->
-          func.apply this, [firstArg, firstArg]
-
-      class MyClass
-        doubleAndSquare:
-          repeatArg \
-          addAndSquareFunction
-
-        add: (x,y)-> x + y
-        square: (n)-> n*n
-
-      eg = new MyClass()
-      expect(eg.doubleAndSquare 4).toBe 64
-
-    it "should should allow actual functions to be threaded as well", ->
+    it "should should allow actual (and my-created) functions to be threaded", ->
 
       add = (x,y)-> x + y
-      addAndSquareFunction = C.helpers.my add, "square"
+      addAndSquareFunction = C.helpers.pipe add, C.helpers.my("square")
       
       repeatArg = (func)->
         (firstArg)->
@@ -510,6 +474,27 @@ describe "helpers", ->
           repeatArg \
           addAndSquareFunction
 
+        square: (n)-> n*n
+
+      eg = new MyClass()
+      expect(eg.doubleAndSquare 4).toBe 64
+
+  describe "pipe my", ->
+
+    it "should pipe through named methods", ->
+
+      addAndSquareFunction = C.helpers.pipeMy "add", "square"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class MyClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+        add: (x,y)-> x + y
         square: (n)-> n*n
 
       eg = new MyClass()

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -330,6 +330,25 @@ describe "Method Combinators", ->
       expect(-> sane.setSanity(true)).not.toThrow 'Failed precondition'
       expect(-> sane.setSanity(false)).not.toThrow 'Failed precondition'
 
+  describe "my combinator", ->
+    it "should reference instance method", ->
+
+      addFunction = C.my "add"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+      
+      class MyClass
+        double:
+          repeatArg \
+          addFunction
+
+        add: (x,y)-> x + y
+
+      eg = new MyClass()
+      expect(eg.double 4).toBe 8
+
 describe "Asynchronous Method Combinators", ->
 
   a = undefined


### PR DESCRIPTION
don't know whether or not this does it for you, but the my-combinator is what I initially considered instead of letting combinators take strings.  You input into "my" a method name and it returns a function that executes that method on the object.  This lets you have a chain like this

``` coffeescript
class Employee
  promote:
    hireSecretary \
    buyBiggerDesk \
    my("updateProfile")
```
