### PR TITLE
Combinator helpers

### DIFF
--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -124,7 +124,7 @@ this.helpers = do (helpers = {}, combinators = this, resolveFunction = undefined
   
   resolveFunction = (func)->
     if typeof func is "string"
-      this[func]
+      helpers.my func
     else
       func
 
@@ -141,7 +141,7 @@ this.helpers = do (helpers = {}, combinators = this, resolveFunction = undefined
       (args...)->
         result = undefined
         for func in functions
-          result = resolveFunction.call(this, func).apply this, args
+          result = resolveFunction(func).apply this, args
           args = [result]
         result
  

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -118,3 +118,15 @@ this.async = do (async = undefined) ->
         async_predicate.apply(this, argv.concat(decorated_base))
 
   async
+
+# ## Combinator Helpers
+this.helpers = do (helpers = {}, combinators = this)->
+
+  # Sugar to reference instance methods by name.
+  helpers.my =
+    (name)->
+      (args...)->
+        func = this[name]
+        func.apply this, args
+
+  helpers

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -120,7 +120,13 @@ this.async = do (async = undefined) ->
   async
 
 # ## Combinator Helpers
-this.helpers = do (helpers = {}, combinators = this)->
+this.helpers = do (helpers = {}, combinators = this, resolveFunction = undefined)->
+  
+  resolveFunction = (func)->
+    if typeof func is "string"
+      this[func]
+    else
+      func
 
   # Sugar to reference instance methods by name.
   helpers.my =
@@ -135,7 +141,7 @@ this.helpers = do (helpers = {}, combinators = this)->
       (args...)->
         result = undefined
         for func in functions
-          result = func.apply this, args
+          result = resolveFunction.call(this, func).apply this, args
           args = [result]
         result
  

--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -129,4 +129,14 @@ this.helpers = do (helpers = {}, combinators = this)->
         func = this[name]
         func.apply this, args
 
+  # Similar to composition & threading macros
+  helpers.pipe  =
+    (functions...)->
+      (args...)->
+        result = undefined
+        for func in functions
+          result = func.apply this, args
+          args = [result]
+        result
+ 
   helpers

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -176,7 +176,7 @@
   this.helpers = (function(helpers, combinators, resolveFunction) {
     resolveFunction = function(func) {
       if (typeof func === "string") {
-        return this[func];
+        return helpers.my(func);
       } else {
         return func;
       }
@@ -198,7 +198,7 @@
         result = void 0;
         for (_i = 0, _len = functions.length; _i < _len; _i++) {
           func = functions[_i];
-          result = resolveFunction.call(this, func).apply(this, args);
+          result = resolveFunction(func).apply(this, args);
           args = [result];
         }
         return result;

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -182,6 +182,21 @@
         return func.apply(this, args);
       };
     };
+    helpers.pipe = function() {
+      var functions;
+      functions = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+      return function() {
+        var args, func, result, _i, _len;
+        args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+        result = void 0;
+        for (_i = 0, _len = functions.length; _i < _len; _i++) {
+          func = functions[_i];
+          result = func.apply(this, args);
+          args = [result];
+        }
+        return result;
+      };
+    };
     return helpers;
   })({}, this);
 

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -173,4 +173,16 @@
     return async;
   })(void 0);
 
+  this.helpers = (function(helpers, combinators) {
+    helpers.my = function(name) {
+      return function() {
+        var args, func;
+        args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+        func = this[name];
+        return func.apply(this, args);
+      };
+    };
+    return helpers;
+  })({}, this);
+
 }).call(this);

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -173,7 +173,14 @@
     return async;
   })(void 0);
 
-  this.helpers = (function(helpers, combinators) {
+  this.helpers = (function(helpers, combinators, resolveFunction) {
+    resolveFunction = function(func) {
+      if (typeof func === "string") {
+        return this[func];
+      } else {
+        return func;
+      }
+    };
     helpers.my = function(name) {
       return function() {
         var args, func;
@@ -191,13 +198,13 @@
         result = void 0;
         for (_i = 0, _len = functions.length; _i < _len; _i++) {
           func = functions[_i];
-          result = func.apply(this, args);
+          result = resolveFunction.call(this, func).apply(this, args);
           args = [result];
         }
         return result;
       };
     };
     return helpers;
-  })({}, this);
+  })({}, this, void 0);
 
 }).call(this);

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -468,3 +468,24 @@ describe "Asynchronous Method Combinators", ->
         decorate(base) 'no', ->
 
         expect(a).toEqual([])
+describe "helpers", ->
+
+  describe "my", ->
+  
+    it "should reference instance method", ->
+
+      addFunction = C.helpers.my "add"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+      
+      class MyClass
+        double:
+          repeatArg \
+          addFunction
+
+        add: (x,y)-> x + y
+
+      eg = new MyClass()
+      expect(eg.double 4).toBe 8

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -492,7 +492,7 @@ describe "helpers", ->
 
   describe "pipe", ->
 
-    it "should allow functions to be threaded", ->
+    it "should thread functions", ->
 
       add = (x,y)-> x + y
       square = (n)-> n*n
@@ -506,6 +506,25 @@ describe "helpers", ->
         doubleAndSquare:
           repeatArg \
           addAndSquareFunction
+
+      eg = new PipeClass()
+      expect(eg.doubleAndSquare 4).toBe 64
+
+    it "should thread named methods", ->
+      
+      addAndSquareFunction = C.helpers.pipe "add", "square"
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class PipeClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+        add: (x,y)-> x + y
+        square: (n)-> n*n
 
       eg = new PipeClass()
       expect(eg.doubleAndSquare 4).toBe 64

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -489,3 +489,23 @@ describe "helpers", ->
 
       eg = new MyClass()
       expect(eg.double 4).toBe 8
+
+  describe "pipe", ->
+
+    it "should allow functions to be threaded", ->
+
+      add = (x,y)-> x + y
+      square = (n)-> n*n
+      addAndSquareFunction = C.helpers.pipe add, square
+      
+      repeatArg = (func)->
+        (firstArg)->
+          func.apply this, [firstArg, firstArg]
+
+      class PipeClass
+        doubleAndSquare:
+          repeatArg \
+          addAndSquareFunction
+
+      eg = new PipeClass()
+      expect(eg.doubleAndSquare 4).toBe 64


### PR DESCRIPTION
This contains the `my` and `pipe` helpers.  `pipe` allows both method names and actual functions because it's IMHO not worth cluttering up the namespace with two separate `pipe` functions.
