### PR TITLE
added actsAs combinator

### DIFF
--- a/lib/method-combinators.coffee
+++ b/lib/method-combinators.coffee
@@ -83,6 +83,32 @@ this.splatter =
         newArgs[0] = element
         base.apply this, newArgs
 
+# Auto-apply methods and remove after invocation
+this.actsAs =
+  (wrappers...)->
+    originalObjects = []
+
+    wrapObject = (object, wrapper)->
+      oldMethods = {}
+      for key, value of wrapper
+        oldMethods[key] = object[key]
+        object[key] = value
+      originalObjects.push oldMethods
+
+    wrapArguments = ->
+      for wrapper, index in wrappers
+        wrapObject arguments[index], wrapper
+
+    revertArguments = ->
+      for oldMethods, index in originalObjects
+        for key, value of oldMethods
+          arguments[index][key] = value
+
+    this.around (func, args...)->
+      wrapArguments args...
+      func()
+      revertArguments args...
+
 # ## Asynchronous Method Combinators
 
 this.async = do (async = undefined) ->

--- a/lib/method-combinators.js
+++ b/lib/method-combinators.js
@@ -114,6 +114,55 @@
     };
   };
 
+  this.actsAs = function() {
+    var originalObjects, revertArguments, wrapArguments, wrapObject, wrappers;
+    wrappers = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+    originalObjects = [];
+    wrapObject = function(object, wrapper) {
+      var key, oldMethods, value;
+      oldMethods = {};
+      for (key in wrapper) {
+        value = wrapper[key];
+        oldMethods[key] = object[key];
+        object[key] = value;
+      }
+      return originalObjects.push(oldMethods);
+    };
+    wrapArguments = function() {
+      var index, wrapper, _i, _len, _results;
+      _results = [];
+      for (index = _i = 0, _len = wrappers.length; _i < _len; index = ++_i) {
+        wrapper = wrappers[index];
+        _results.push(wrapObject(arguments[index], wrapper));
+      }
+      return _results;
+    };
+    revertArguments = function() {
+      var index, key, oldMethods, value, _i, _len, _results;
+      _results = [];
+      for (index = _i = 0, _len = originalObjects.length; _i < _len; index = ++_i) {
+        oldMethods = originalObjects[index];
+        _results.push((function() {
+          var _results1;
+          _results1 = [];
+          for (key in oldMethods) {
+            value = oldMethods[key];
+            _results1.push(arguments[index][key] = value);
+          }
+          return _results1;
+        }).apply(this, arguments));
+      }
+      return _results;
+    };
+    return this.around(function() {
+      var args, func;
+      func = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+      wrapArguments.apply(null, args);
+      func();
+      return revertArguments.apply(null, args);
+    });
+  };
+
   this.async = (function(async) {
     async = function(fn) {
       return function() {

--- a/spec/method-combinators.spec.coffee
+++ b/spec/method-combinators.spec.coffee
@@ -364,6 +364,61 @@ describe "Method Combinators", ->
 
       expect(value[1]).toBe(1)        
 
+  describe "actsAs", ->
+
+    it "wraps input object in another object", ->
+          
+      b = updateCounter: ->
+        @counter++
+
+      decorator = C.actsAs(b)    
+
+      counterObject = { counter: 1 } 
+      
+      class ActsAsClazz
+        update: decorator (obj)->
+          obj.updateCounter() 
+      
+      result = new ActsAsClazz().update(counterObject)
+      expect(counterObject.counter).toBe(2)
+      expect(result).toBe(1)
+      expect(counterObject.updateCounter).toBe(undefined)
+
+    it "wraps later arguments", ->
+          
+      b = updateCounter: ->
+        @counter++
+
+      decorator = C.actsAs(null,b)
+
+      counterObject = { counter: 1 } 
+      
+      class ActsAsClazz
+        update: decorator (placeholder, obj)->
+          obj.updateCounter() 
+      
+      new ActsAsClazz().update(null, counterObject)
+      expect(counterObject.counter).toBe(2)
+      expect(counterObject.updateCounter).toBe(undefined)
+
+    it "alternatively wraps input object in a class's static methods", ->
+          
+      class b
+        @updateCounter: ->
+          @counter++
+
+      decorator = C.actsAs(b)    
+
+      counterObject = { counter: 1 } 
+      
+      class ActsAsClazz
+        update: decorator (obj)->
+          obj.updateCounter() 
+      
+      new ActsAsClazz().update(counterObject)
+      expect(counterObject.counter).toBe(2)
+      expect(counterObject.updateCounter).toBe(undefined)
+
 describe "Asynchronous Method Combinators", ->
 
   a = undefined


### PR DESCRIPTION
Okay, this was a fun xmas one while my toddler is napping.

I used your `around` combinator to build an `actsAs` combinator. This assigns roles a la DCI.

So the equivalent of this ruby DCI example:

``` ruby
def initialize source_account, destination_account
    @source_account = source_account.extend SourceAccount
    @destination_account = destination_account.extend DestinationAccount
    doStuff...
end
```

is the hotter

``` coffeescript
initialize: actsAs(SourceAccount, DestinationAccount) (@sourceAccount, @destinationaccount)->
  doStuff...
```

This has the big benefit of removing the role after the method invocation (whereas in the ruby example the modules crash the inheritance party).  I named it `actAs` as an obvious "shout out".

Also, `actsAs` takes objects as input and steals their methods for the target objects. If the parameters to `actsAs` are instead classes, then it steals their class methods, not instance methods.
